### PR TITLE
Allow binning if PARAM_BINNING_* is not defined

### DIFF
--- a/src/pyvcam/camera.py
+++ b/src/pyvcam/camera.py
@@ -853,7 +853,10 @@ class Camera:
     @bin_x.setter
     def bin_x(self, value):
         # Will raise ValueError if incompatible binning is set
-        if value in self.read_enum(const.PARAM_BINNING_SER).values():
+        if (
+            not self.check_param(const.PARAM_BINNING_SER) or
+            value in self.read_enum(const.PARAM_BINNING_SER).values()
+        ):
             for roi in self.__rois:
                 roi.sbin = value
             return
@@ -868,7 +871,10 @@ class Camera:
     @bin_y.setter
     def bin_y(self, value):
         # Will raise ValueError if incompatible binning is set
-        if value in self.read_enum(const.PARAM_BINNING_PAR).values():
+        if (
+            not self.check_param(const.PARAM_BINNING_PAR) or 
+            value in self.read_enum(const.PARAM_BINNING_PAR).values()
+        ):
             for roi in self.__rois:
                 roi.pbin = value
             return


### PR DESCRIPTION
Hello everyone,

The Photon Max 512 supports arbitrary binning sizes, but because it doesn’t expose `PARAM_BINNING_SER` or `PARAM_BINNING_PAR`, PyVCAM currently blocks any calls to set `bin_X` or `bin_Y`.  

This PR updates the binning‐validation logic so that if those properties are missing, we simply skip the range check and allow arbitrary binning.  

I’ve only been able to test this on the Photon Max 512, so I’m not certain how it might affect other models. Any feedback or suggestions on potential side effects would be greatly appreciated!

Thanks for reviewing.

